### PR TITLE
[ChessGame] Do not allow bots to play.

### DIFF
--- a/chessgame/chessgame.py
+++ b/chessgame/chessgame.py
@@ -55,6 +55,14 @@ class ChessGame(commands.Cog):
         embed.title = "Chess"
         embed.description = "New Game"
 
+        if other_player.bot:
+            bot = other_player
+            embed.add_field(
+                name=f"{bot} is a bot!",
+                value=f"You cannot start a game with a bot.")
+            message = await ctx.send(embed=embed)
+            return 
+
         embed.add_field(
             name=f"{ctx.author.name} would like to start a game!",
             value=f"<@{other_player.id}> respond below:")


### PR DESCRIPTION
Hello,
As you suggested, here is the code to prevent a member from starting a game with a bot.
If, one day, a bot becomes able to play, someone will ask here to unblock.
Anyway, the command "[p]chess move" is not usable by a bot.
Thanks in advance.